### PR TITLE
makefile: Add gwwm/popup.scm to nobase_guilemodule_DATA.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ nobase_guilemodule_DATA = gwwm.scm \
 		gwwm/keybind.scm \
 		gwwm/keyboard.scm \
 		gwwm/pointer.scm \
+		gwwm/popup.scm \
 		gwwm/touch.scm \
 		gwwm/user.scm \
 		gwwm/buffer.scm \


### PR DESCRIPTION
Thanks again for all these repos!

I finally managed to get it all running. Guix packaging works when using a full [.guix/modules/gwwm-packages.scm](https://gitlab.com/wehlutyk/edl/-/blob/main/.guix/modules/gwwm-packages.scm) declaring all your packages together (following Guix's Cookbook [The Repository as a Channel](https://guix.gnu.org/cookbook/en/html_node/The-Repository-as-a-Channel.html)). Once packaging with guix shell worked, the last fix to run it was this patch.

Now `guix shell -L $PWD/.guix/modules gwwm -- gwwm` works.